### PR TITLE
Matching of name in name-value pairs on the command line is too permissive.

### DIFF
--- a/lib/luke/cli.lua
+++ b/lib/luke/cli.lua
@@ -97,7 +97,7 @@ return {
 
             ['--version'] = version,
 
-            ['(.+)=(.+)'] = function(name, value)
+            ['([^=]+)=(.+)'] = function(name, value)
                clidefs[name] = value
             end,
 


### PR DESCRIPTION
I found this issue while building luaposix.  If a name=value
pair is given on the command line, luke allows the name to
contain an equals sign, since the match (.+)=(.+)
greedily matches = in the name.
I don't think there should be a reason to allow = in variable names.
